### PR TITLE
Was making error in python3 because / return float.

### DIFF
--- a/moteapi.py
+++ b/moteapi.py
@@ -16,7 +16,7 @@ status = 0
 def hex_to_rgb(value):
     value = value.lstrip('#')
     length = len(value)
-    return tuple(int(value[i:i + length / 3], 16) for i in range(0, length, length / 3))
+    return tuple(int(value[i:i + length // 3], 16) for i in range(0, length, length // 3))
 
 def mote_on(c):
     r, g, b = hex_to_rgb(c)


### PR DESCRIPTION
For python3 and python2 compatibility // return int in both.

At least it works for me now.